### PR TITLE
Memory Leak Fix - CubismMotionSyncEngineAnalysisResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * Implement support for `MSVC19.40` in the VS2022 build. by [@tatsuya-shiozawa](https://github.com/Live2D/CubismNativeMotionSyncComponents/pull/3)
+* Fix memory leak in `CubismMotionSyncEngineAnalysisResult` objects. by [@tatsuya-shiozawa](https://github.com/Live2D/CubismNativeMotionSyncComponents/pull/4)
 
 
 ## [5-r.1] - 2024-05-30

--- a/Framework/src/CubismMotionSync.cpp
+++ b/Framework/src/CubismMotionSync.cpp
@@ -248,6 +248,7 @@ CubismMotionSync::CubismMotionSync(CubismModel* model, CubismMotionSyncData *dat
     {
         _processorInfoList.PushBack(CubismProcessorInfo(processorList[i], model, data->GetSetting(i)));
         _processorInfoList[i].Init(data->GetSetting(i));
+        CubismProcessorInfo::CreateAnalysisResult(&_processorInfoList[i]);
     }
 }
 
@@ -258,6 +259,7 @@ CubismMotionSync::~CubismMotionSync()
     {
         if (_processorInfoList[i]._processor)
         {
+            CubismProcessorInfo::DeleteAnalysisResult(&_processorInfoList[i]);
             _processorInfoList[i]._processor->Close();
         }
     }

--- a/Framework/src/CubismMotionSync.hpp
+++ b/Framework/src/CubismMotionSync.hpp
@@ -108,10 +108,10 @@ private:
             _audioLevelEffectRatio(0.0f),
             _samplesAudioBuff(NULL),
             _model(model),
+            _analysisResult(NULL),
             _currentRemainTime(0.0f)
         {
             Init(setting);
-            _analysisResult = _processor->CreateAnalysisResult();
         }
 
         /**
@@ -138,6 +138,28 @@ private:
             _blendRatio = setting.blendRatio;
             _smoothing = setting.smoothing;
             _sampleRate = setting.sampleRate;
+        }
+
+        /**
+         * @brief 解析結果を格納するクラスのインスタンスを生成する
+         *
+         * @param[in]   info    このクラスのインスタンス
+         * 
+         */
+        static void CreateAnalysisResult(CubismProcessorInfo* info)
+        {
+            info->_analysisResult = info->_processor->CreateAnalysisResult();
+        }
+
+        /**
+         * @brief 解析結果を格納するクラスのインスタンスを破棄する
+         *
+         * @param[in]   info    このクラスのインスタンス
+         *
+         */
+        static void DeleteAnalysisResult(CubismProcessorInfo* info)
+        {
+            info->_processor->DeleteAnalysisResult(info->_analysisResult);
         }
 
         ICubismMotionSyncProcessor *_processor;

--- a/Framework/src/ICubismMotionSyncProcessor.cpp
+++ b/Framework/src/ICubismMotionSyncProcessor.cpp
@@ -26,6 +26,7 @@ void ICubismMotionSyncProcessor::DeleteAnalysisResult(CubismMotionSyncEngineAnal
     if (analysisResult)
     {
         CSM_DELETE(analysisResult);
+        analysisResult = NULL;
     }
 }
 

--- a/Framework/src/ICubismMotionSyncProcessor.cpp
+++ b/Framework/src/ICubismMotionSyncProcessor.cpp
@@ -21,6 +21,14 @@ CubismMotionSyncEngineAnalysisResult* ICubismMotionSyncProcessor::CreateAnalysis
     return CSM_NEW CubismMotionSyncEngineAnalysisResult(_mappingInfoArray[0].GetModelParameterValues().GetSize());
 }
 
+void ICubismMotionSyncProcessor::DeleteAnalysisResult(CubismMotionSyncEngineAnalysisResult* analysisResult)
+{
+    if (analysisResult)
+    {
+        CSM_DELETE(analysisResult);
+    }
+}
+
 Framework::csmVector<CubismMotionSyncEngineMappingInfo> ICubismMotionSyncProcessor::GetMappingInfoArray()
 {
     return _mappingInfoArray;

--- a/Framework/src/ICubismMotionSyncProcessor.hpp
+++ b/Framework/src/ICubismMotionSyncProcessor.hpp
@@ -26,6 +26,14 @@ public:
     CubismMotionSyncEngineAnalysisResult* CreateAnalysisResult();
 
     /**
+     * @brief 解析結果を格納するクラスのインスタンスを破棄する
+     *
+     * @param[in]   analysisResult    破棄対象のインスタンス
+     *
+     */
+    void DeleteAnalysisResult(CubismMotionSyncEngineAnalysisResult* analysisResult);
+
+    /**
      * @brief モーションシンクの解析時に使用するマッピング情報のクラスを取得する
      *
      * @return モーションシンクの解析時に使用するマッピング情報のクラス


### PR DESCRIPTION
(Sorry for machine translation...)
# Pull Request: Memory Leak Fix - CubismMotionSyncEngineAnalysisResult

## Overview
This Pull Request addresses a memory leak associated with the `CubismMotionSyncEngineAnalysisResult` object.

## Changes
1. Added new methods to the `CubismProcessorInfo` class:
   - `CreateAnalysisResult`
   - `DeleteAnalysisResult`
2. Added a new method to the `ICubismMotionSyncProcessor` class:
   - `DeleteAnalysisResult`
3. Modified the initialization and termination processes of the `CubismMotionSync` class

## Intent of the Fix
The main objectives of this fix are to improve memory management and enhance code readability. Specifically, the intentions are as follows:

1. Resolving memory leaks: We've addressed the issue where `CreateAnalysisResult` calls `CSM_NEW`, but there was no corresponding `CSM_DELETE` call.
2. Improving code readability: We implemented the `CSM_DELETE` call in the `ICubismMotionSyncProcessor.cpp` source file. This makes it easier to recognize the pairing relationship between `CSM_NEW` and `CSM_DELETE`, thereby improving code readability.
3. Clarifying design intent: `CubismProcessorInfo::CreateAnalysisResult` and `CubismProcessorInfo::DeleteAnalysisResult` are functions that encapsulate the calls to `CSM_NEW` and `CSM_DELETE`. To express the intent of providing Factory API functionality, we implemented these as static functions.
4. Consistency with existing design: While there are some code differences that involve design changes, we've taken care to minimize alterations to the current class design intent. This allows us to maintain consistency with the existing codebase while making necessary improvements.

These changes are expected to enhance the reliability of memory management while also improving code maintainability and readability.

## Technical Details
1. Added `CubismProcessorInfo::CreateAnalysisResult` and `CubismProcessorInfo::DeleteAnalysisResult` methods to centralize the creation and deletion of `_analysisResult`.
2. Added the `ICubismMotionSyncProcessor::DeleteAnalysisResult` method to properly delete `CubismMotionSyncEngineAnalysisResult` objects.
3. Modified the `CubismMotionSync` class to call `CreateAnalysisResult` during initialization and `DeleteAnalysisResult` during termination.

## Scope of Impact
While these changes may affect how the CubismMotionSync and CubismProcessorInfo classes are used, there are no changes to the API as seen from the application level, so application-layer source code should not be affected. However, if the application side has been using CSM_DELETE to free the _analysisResult (which was allocated with CSM_NEW in the Framework) as a measure against memory leaks, there is a risk of double freeing. In such cases, the issue can be resolved by announcing that memory is being properly freed within the Framework and removing the deallocation process at the application layer.

## Verification Method
To confirm the memory leak fix, follow these steps:
1. Add `CSM_DEBUG_MEMORY_LEAKING` to the compile definitions.
2. Build the project.
3. Run the application.

By building and running with this setting, you can confirm that the memory leak related to the `_analysisResult` object has been resolved. This method allows you to directly observe the effect of the fix.

---
# Pull Request: メモリリーク修正 - CubismMotionSyncEngineAnalysisResult

## 概要
この Pull Request は、`CubismMotionSyncEngineAnalysisResult` オブジェクトに関連するメモリリークを修正するものです。

## 変更内容

1. `CubismProcessorInfo` クラスに新しいメソッドを追加:
   - `CreateAnalysisResult`
   - `DeleteAnalysisResult`

2. `ICubismMotionSyncProcessor` クラスに新しいメソッドを追加:
   - `DeleteAnalysisResult`

3. `CubismMotionSync` クラスの初期化と終了処理を修正

## 修正の意図

この修正は、メモリ管理の改善と可読性の向上を主な目的としています。具体的には以下の意図があります：

1. メモリリークの解消：`CreateAnalysisResult`では`CSM_NEW`によるメモリ確保が行われている一方で、その対となる`CSM_DELETE`によるメモリ解放処理が存在しないという問題を解決しました。

2. コードの可読性向上：`CreateAnalysisResult`インスタンスに対する`CSM_DELETE`の呼び出しの実装を`ICubismMotionSyncProcessor.cpp`のソースファイルに実装しました。これにより、`CSM_NEW`と`CSM_DELETE`のペアが対となる関係であることを認識しやすくなり、コードの可読性が向上します。

3. 設計意図の明確化：`CubismProcessorInfo::CreateAnalysisResult` と `CubismProcessorInfo::DeleteAnalysisResult` は、`CSM_NEW`と`CSM_DELETE`の呼び出しを内包している関数であってFactory APIの機能を提供する、という意図を表現するために、これらを静的（static）関数として実装しました。

4. 既存設計との整合性：一部設計変更を伴うコード差分がありますが、現状のクラス設計の意図を極力変更しないように配慮しました。これにより、既存のコードベースとの整合性を保ちつつ、必要な改善を行っています。

これらの変更により、メモリ管理の信頼性が向上し、同時にコードの保守性と可読性も改善されることが期待されます。

## 技術的な詳細

1. `CubismProcessorInfo::CreateAnalysisResult` と `CubismProcessorInfo::DeleteAnalysisResult` メソッドを追加し、`_analysisResult` の作成と削除を一元管理します。

2. `ICubismMotionSyncProcessor::DeleteAnalysisResult` メソッドを追加し、`CubismMotionSyncEngineAnalysisResult` オブジェクトの適切な削除を行います。

3. `CubismMotionSync` クラスの初期化時に `CreateAnalysisResult` を呼び出し、終了時に `DeleteAnalysisResult` を呼び出すように変更しました。

## 影響範囲
この変更は、`CubismMotionSync` と `CubismProcessorInfo` クラスの使用方法に影響を与える可能性がありますが、アプリケーションから見たAPIに変更は無いため、アプリケーション階層のソースコードには影響は発生しません。ただし、アプリケーション側のメモリリーク対策として、Framework内でCSM_NEWで確保した`_analysisResult`をアプリケーション階層側でCSM_DELETEで解放している場合は、二重解放に遭遇する恐れがあります。その場合は、Framework内で適切にメモリ解放が行われていることをアナウンスしてアプリケーション階層の解放処理を削除することで課題を解消できます。

## 動作確認方法

メモリリークの修正を確認するには、以下の手順を実行してください：

1. コンパイル定義に `CSM_DEBUG_MEMORY_LEAKING` を追加します。
2. プロジェクトをビルドします。
3. アプリケーションを実行します。

この設定でビルドし実行することで、`_analysisResult`オブジェクトに関連するメモリリークが解消されたことが確認できます。この方法により、修正の効果を直接観察することができます。